### PR TITLE
Fix deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,30 +1,30 @@
 # tasks file for ssh-keys
 ---
-- include: general.yml
+- include_tasks: general.yml
   tags:
     - configuration
     - ssh-keys
     - ssh-keys-general
 
-- include: private-keys.yml
+- include_tasks: private-keys.yml
   tags:
     - configuration
     - ssh-keys
     - ssh-keys-private-keys
 
-- include: public-keys.yml
+- include_tasks: public-keys.yml
   tags:
     - configuration
     - ssh-keys
     - ssh-keys-public-keys
 
-- include: authorized-keys.yml
+- include_tasks: authorized-keys.yml
   tags:
     - configuration
     - ssh-keys
     - ssh-keys-authorized-keys
 
-- include: known-hosts.yml
+- include_tasks: known-hosts.yml
   tags:
     - configuration
     - ssh-keys

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,7 +4,7 @@
   connection: local
   become: true
   pre_tasks:
-    - include: pre.yml
+    - include_tasks: pre.yml
   roles:
     - ../../
   vars:


### PR DESCRIPTION
This should fix #11. For this case, it's simply a change of the name as can be seen in the [Ansible documentation](http://docs.ansible.com/ansible/latest/playbooks_reuse.html).