### PR TITLE
Adds collections metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,3 +23,6 @@ galaxy_info:
   - system
   - networking
 dependencies: []
+collections:
+  - ansible.posix
+  - community.crypto


### PR DESCRIPTION
Ansible 2.10 is moving to a new organization for modules, collections. Each role will need (as it stands now) to specify the collections it requires. This PR adds this information. 

Although this will be used by 2.10, it does not break in any way earlier versions of Ansible. As a lot of people use ansible from a checkout of the development branch, it may be useful to support those users of your role, like myself.