### PR TITLE
Reverts ternaries to inline conditionals

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,7 +8,7 @@ _ssh_keys_generate_command: >-
   openssl \
     gen{{ item.type | default('rsa') }} \
     -out {{ item.path }} \
-    {{ ('cipher' in item) | ternary('-' + item.cipher, '') }} \
-    {{ ('passphrase' in item) | ternary('-passout stdin', '') }} \
+    {{ item.cipher if item.cipher is defined else '' }} \
+    {{ '-passout stdin' if item.passphrase is defined else '' }} \
     {{ item.size | default(4096) }} \
-    {{ ('passphrase' in item) | ternary('<<< "' + item.passphrase + '"', '') }}
+    {{  '<<< "' + item.passphrase + '"' if item.passphrase is defined else '' }}


### PR DESCRIPTION
In #14, I changed inline conditionals like:

```
"{{ item.cipher if item.cipher is defined else '' }}"
```

to ternaries:

```
"{{ (item.cipher is defined) | ternary(item.cipher, '') }}"
```

The problem with the `ternary` filter is that when called it tries to evaluate its arguments. In the case where `item.cipher` is not defined, the filter will fail to evaluate its first argument. In other words the boolean input is useless as a check.

In this PR, I revert the ternaries to inline conditionals.