### PR TITLE
Adds option to not become when generating keys locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ None
 * `ssh_keys_known_hosts.{n}.enctype`: [required]: The type of the fingerprint
 * `ssh_keys_known_hosts.{n}.fingerprint`: [required]: The actual fingerprint
 
+* `ssh_keys_generate_keys_local_become`: [optional, default: false]: Whether to use sudo when generating ssh keys locally
+
 ## Dependencies
 
 None

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ ssh_keys_private_keys: []
 ssh_keys_public_keys: []
 ssh_keys_authorized_keys: []
 ssh_keys_known_hosts: []
+ssh_keys_generate_keys_local_become: false

--- a/tasks/generate.yml
+++ b/tasks/generate.yml
@@ -45,5 +45,5 @@
       with_items: "{{ ssh_keys_generate_keys }}"
       tags:
         - ssh-keys-generate-public-keys
-  connection: local
+  delegate_to: localhost
   become: "{{ ssh_keys_generate_keys_local_become }}"

--- a/tasks/generate.yml
+++ b/tasks/generate.yml
@@ -46,3 +46,4 @@
       tags:
         - ssh-keys-generate-public-keys
   connection: local
+  become: "{{ ssh_keys_generate_keys_local_become }}"


### PR DESCRIPTION
When generating keys, the role runs the key generation tasks with `connection: local`. However, most probably the role will be run with `become: true` to be able to edit users' ssh-related files on the remote hosts. But in this case the local tasks will also run as root. This might not be what the user wants. For instance, `sudo` may require a password locally and this will break ansible if no become_password is provided.