### PR TITLE
Adds option to set authorized keys path

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ None
 * `ssh_keys_authorized_keys`: [default: `[]`]: Authorized key declarations
 * `ssh_keys_authorized_keys.{n}.owner`: [required]: The name of the user that should own the file
 * `ssh_keys_authorized_keys.{n}.src`: [required]: The local path of the key
-* `ssh_keys_authorized_keys.{n}.state`: [default: `present`]: State
+* `ssh_keys_authorized_keys.{n}.state`: [optional, default: `present`]: State
+* `ssh_keys_authorized_keys.{n}.path`: [optional, default: `authorized_keys`]: Authorized keys file (relative to `home/.ssh/`)
 
 * `ssh_keys_known_hosts`: [default: `[]`]: Known hosts declarations
 * `ssh_keys_known_hosts.{n}.hostname`: [required]: The hostname

--- a/tasks/authorized-keys.yml
+++ b/tasks/authorized-keys.yml
@@ -5,6 +5,7 @@
     user: "{{ item.owner }}"
     key: "{{ lookup('file', item.src) }}"
     state: "{{ item.state | default('present') }}"
+    path: "~/.ssh/{{ item.path | default('authorized_keys') }}"
   with_items: "{{ ssh_keys_authorized_keys }}"
   tags:
     ssh-keys-authorized-keys-setup


### PR DESCRIPTION
In openssh, there is the option to specify the path to the authorized keys file. This is handy for instance to separate authorized keys if there are more than one ssh servers running on the instance.

This PR adds an option `path` to the authorized keys to specify where the authorized key should be uploaded to.