### PR TITLE
Fix path expansion for authorized_keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ None
 * `ssh_keys_authorized_keys.{n}.owner`: [required]: The name of the user that should own the file
 * `ssh_keys_authorized_keys.{n}.src`: [required]: The local path of the key
 * `ssh_keys_authorized_keys.{n}.state`: [optional, default: `present`]: State
-* `ssh_keys_authorized_keys.{n}.path`: [optional, default: `authorized_keys`]: Authorized keys file (relative to `home/.ssh/`)
+* `ssh_keys_authorized_keys.{n}.path`: [optional, default: `authorized_keys`]: Authorized keys file (absolute path, default to `~/.ssh/authorized_keys`)
 
 * `ssh_keys_known_hosts`: [default: `[]`]: Known hosts declarations
 * `ssh_keys_known_hosts.{n}.hostname`: [required]: The hostname

--- a/tasks/authorized-keys.yml
+++ b/tasks/authorized-keys.yml
@@ -5,7 +5,7 @@
     user: "{{ item.owner }}"
     key: "{{ lookup('file', item.src) }}"
     state: "{{ item.state | default('present') }}"
-    path: "{{ item_path | default('~' + item.owner + '/.ssh/authorized_keys') }}"
+    path: "{{ item.path | default('~' + item.owner + '/.ssh/authorized_keys') }}"
   with_items: "{{ ssh_keys_authorized_keys }}"
   tags:
     ssh-keys-authorized-keys-setup

--- a/tasks/authorized-keys.yml
+++ b/tasks/authorized-keys.yml
@@ -5,7 +5,7 @@
     user: "{{ item.owner }}"
     key: "{{ lookup('file', item.src) }}"
     state: "{{ item.state | default('present') }}"
-    path: "~/.ssh/{{ item.path | default('authorized_keys') }}"
+    path: "{{ item_path | default('~' + item.owner + '/.ssh/authorized_keys') }}"
   with_items: "{{ ssh_keys_authorized_keys }}"
   tags:
     ssh-keys-authorized-keys-setup


### PR DESCRIPTION
If defining multiple users with keys slated for authorized keys, Due to impropper `~` expansion owner is set to the last user and the key end up in `/root/.ssh/authorized_keys` instead of users one.

Fixes #26