### PR TITLE
unquote ssh_keys_sshdir in authorized-keys.yml for propper expansion

### DIFF
--- a/tasks/authorized-keys.yml
+++ b/tasks/authorized-keys.yml
@@ -5,7 +5,7 @@
     user: "{{ item.owner }}"
     key: "{{ lookup('file', item.src) }}"
     state: "{{ item.state | default('present') }}"
-    path: "{{ item.path | default('~' + item.owner + '/{{ ssh_keys_sshdir }}/authorized_keys') }}"
+    path: "{{ item.path | default('~' + item.owner + '/' + {{ ssh_keys_sshdir }} + '/authorized_keys') }}"
   with_items: "{{ ssh_keys_authorized_keys }}"
   tags:
     ssh-keys-authorized-keys-setup


### PR DESCRIPTION
Due to mechanical replacement of `.ssh` with `{{ ssh_keys_sshdir }}` the keys we want to place do not land again in the right place.